### PR TITLE
Add basic failure logging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ const EKG = function() {
             stack,
           },
         ]
+        console.error(`${check.name} failed because ${message}`)
       }
     }
     send(res, results.find(r => !r.passed) ? 503 : 200, results)


### PR DESCRIPTION
So you can see why your check failed from `kubectl logs`